### PR TITLE
Remove iron plate from Rusty wh/stall recipes. Add iron stall to stall types.

### DIFF
--- a/mods/canmarket/assets/canmarket/blocktypes/canstall.json
+++ b/mods/canmarket/assets/canmarket/blocktypes/canstall.json
@@ -31,7 +31,7 @@
         }
       }
     },
-    "types": [ "rusty" ]
+    "types": [ "rusty", "iron" ]
   },
   "textures": {
     "rusty-stall-body": { "base": "game:block/machine/device-plate" },

--- a/mods/canmarket/assets/canmarket/recipes/grid/canstall.json
+++ b/mods/canmarket/assets/canmarket/recipes/grid/canstall.json
@@ -5,7 +5,7 @@
       "P": {
         "type": "item",
         "code": "game:metalplate-*",
-        "allowedVariants": [ "copper", "brass", "blackbronze", "tinbronze", "bismuthbronze", "iron" ],
+        "allowedVariants": [ "copper", "brass", "blackbronze", "tinbronze", "bismuthbronze" ],
         "name": "material",
         "quantity": 2
       },

--- a/mods/canmarket/assets/canmarket/recipes/grid/canwarehouse.json
+++ b/mods/canmarket/assets/canmarket/recipes/grid/canwarehouse.json
@@ -5,7 +5,7 @@
       "P": {
         "type": "item",
         "code": "game:metalplate-*",
-        "allowedVariants": [ "copper", "brass", "blackbronze", "tinbronze", "bismuthbronze", "iron" ],
+        "allowedVariants": [ "copper", "brass", "blackbronze", "tinbronze", "bismuthbronze" ],
         "name": "material",
         "quantity": 2
       },


### PR DESCRIPTION
Resolves #8 and #9 
• Removes iron plates from crafting recipes for Rusty Stall & Rusty Warehouse, preventing recipe overlap with Iron stall.
• Adds type "iron" to stall types so that iron stalls can drop from iron stalls.
